### PR TITLE
Remove dependency on `top`

### DIFF
--- a/xk_handler/xk_index.py
+++ b/xk_handler/xk_index.py
@@ -154,7 +154,7 @@ class IndexHandler(BaseHandler):
         for cpu in cpu_infos:
             Total += cpu_infos[cpu]['total']
             Idle += cpu_infos[cpu]['idle']
-        return ((Total-Idle)/Total)*100
+        return (math.ceil((((Total-Idle)/Total)*100)*100))/100
 
     @Auth
     def get(self):

--- a/xk_handler/xk_index.py
+++ b/xk_handler/xk_index.py
@@ -117,32 +117,10 @@ class IndexHandler(BaseHandler):
             4idle: twiddling thumbs
             5iowait: waiting for I/O to complete
             6irq: servicing inte   def getcpuload(self):
-        '''
-        CPU_Percentage=((Total-PrevTotal)-(Idle-PrevIdle))/(Total-PrevTotal)
-
-        '''
-        start = self.getcputime()
-        #wait a second
-        sleep(self.sleeptime)
-        stop = self.getcputime()
-
-        cpu_load = {}
-
-        for cpu in start:
-            Total = stop[cpu]['total']
-            PrevTotal = start[cpu]['total']
-
-            Idle = stop[cpu]['idle']
-            PrevIdle = start[cpu]['idle']
-            CPU_Percentage=((Total-PrevTotal)-(Idle-PrevIdle))/(Total-PrevTotal)*100
-            cpu_load.update({cpu: CPU_Percentage})
-        return cpu_loadrrupts
-            7softirq: servicing softirqs
 
         #the formulas from htop 
              user    nice   system  idle      iowait irq   softirq  steal  guest  guest_nice
         cpu  74608   2520   24433   1117073   6176   4054  0        0      0      0
-
 
         Idle=idle+iowait
         NonIdle=user+nice+system+irq+softirq+steal

--- a/xk_handler/xk_index.py
+++ b/xk_handler/xk_index.py
@@ -130,7 +130,7 @@ class IndexHandler(BaseHandler):
         '''
         cpu_infos = {} #collect here the information
         with open('/proc/stat','r') as f_stat:
-            lines = [line.split(self.sep) for content in f_stat.readlines() for line in content.split('\n') if line.startswith('cpu')]
+            lines = [line.split(' ') for content in f_stat.readlines() for line in content.split('\n') if line.startswith('cpu')]
 
         #compute for every cpu
         

--- a/xk_handler/xk_index.py
+++ b/xk_handler/xk_index.py
@@ -153,7 +153,7 @@ class IndexHandler(BaseHandler):
         Idle = 0
         for cpu in cpu_infos:
             Total += cpu_infos[cpu]['total']
-            Idle += stop[cpu]['idle']
+            Idle += cpu_infos[cpu]['idle']
         return ((Total-Idle)/Total)*100
 
     @Auth

--- a/xk_handler/xk_index.py
+++ b/xk_handler/xk_index.py
@@ -149,10 +149,12 @@ class IndexHandler(BaseHandler):
 
     def get_cpu(self):
         cpu_infos = self.get_cpuinfo()
+        Total = 0
+        Idle = 0
         for cpu in cpu_infos:
             Total += cpu_infos[cpu]['total']
             Idle += stop[cpu]['idle']
-        return ((Total-Idle)/Total)
+        return ((Total-Idle)/Total)*100
 
     @Auth
     def get(self):

--- a/xk_handler/xk_index.py
+++ b/xk_handler/xk_index.py
@@ -2,7 +2,7 @@
 #-*- coding:utf8 -*-
 # Desgin By Xiaok
 from xk_application.xk_main import *
-import platform,os
+import platform,os,sys
 
 class IndexHandler(BaseHandler):
     def get_hostname(self):
@@ -105,10 +105,73 @@ class IndexHandler(BaseHandler):
         version = v1.read().strip()
         return {"version":version, "status":status}
 
+    def get_cpuinfo(self):
+        '''
+        http://stackoverflow.com/questions/23367857/accurate-calculation-of-cpu-usage-given-in-percentage-in-linux
+        read in cpu information from file
+        The meanings of the columns are as follows, from left to right:
+            0cpuid: number of cpu
+            1user: normal processes executing in user mode
+            2nice: niced processes executing in user mode
+            3system: processes executing in kernel mode
+            4idle: twiddling thumbs
+            5iowait: waiting for I/O to complete
+            6irq: servicing inte   def getcpuload(self):
+        '''
+        CPU_Percentage=((Total-PrevTotal)-(Idle-PrevIdle))/(Total-PrevTotal)
+
+        '''
+        start = self.getcputime()
+        #wait a second
+        sleep(self.sleeptime)
+        stop = self.getcputime()
+
+        cpu_load = {}
+
+        for cpu in start:
+            Total = stop[cpu]['total']
+            PrevTotal = start[cpu]['total']
+
+            Idle = stop[cpu]['idle']
+            PrevIdle = start[cpu]['idle']
+            CPU_Percentage=((Total-PrevTotal)-(Idle-PrevIdle))/(Total-PrevTotal)*100
+            cpu_load.update({cpu: CPU_Percentage})
+        return cpu_loadrrupts
+            7softirq: servicing softirqs
+
+        #the formulas from htop 
+             user    nice   system  idle      iowait irq   softirq  steal  guest  guest_nice
+        cpu  74608   2520   24433   1117073   6176   4054  0        0      0      0
+
+
+        Idle=idle+iowait
+        NonIdle=user+nice+system+irq+softirq+steal
+        Total=Idle+NonIdle # first line of file for all cpus
+
+        CPU_Percentage=((Total-PrevTotal)-(Idle-PrevIdle))/(Total-PrevTotal)
+        '''
+        cpu_infos = {} #collect here the information
+        with open('/proc/stat','r') as f_stat:
+            lines = [line.split(self.sep) for content in f_stat.readlines() for line in content.split('\n') if line.startswith('cpu')]
+
+        #compute for every cpu
+        
+        for cpu_line in lines:
+            if '' in cpu_line: cpu_line.remove('')#remove empty elements
+            cpu_line = [cpu_line[0]]+[float(i) for i in cpu_line[1:]]#type casting
+            cpu_id,user,nice,system,idle,iowait,irq,softrig,steal,guest,guest_nice = cpu_line
+
+            Idle=idle+iowait
+            NonIdle=user+nice+system+irq+softrig+steal
+
+            Total=Idle+NonIdle
+            #update dictionionary
+            cpu_infos.update({cpu_id:{'total':Total,'idle':Idle}})
+        return cpu_infos
+
     def get_cpu(self):
-        cpu = os.popen('top -bi -n 1').read().split('\n')[2]
-        cpu = cpu.split(", ")[3].split('%')[0]
-        return 100.0 - float(cpu)
+        cpu_infos = get_cpuinfo()
+        return (cpu_infos['']['idle']/cpu_infos['']['total'])
 
     @Auth
     def get(self):

--- a/xk_handler/xk_index.py
+++ b/xk_handler/xk_index.py
@@ -149,7 +149,10 @@ class IndexHandler(BaseHandler):
 
     def get_cpu(self):
         cpu_infos = self.get_cpuinfo()
-        return (cpu_infos['']['idle']/cpu_infos['']['total'])
+        for cpu in cpu_infos:
+            Total += cpu_infos[cpu]['total']
+            Idle += stop[cpu]['idle']
+        return ((Total-Idle)/Total)
 
     @Auth
     def get(self):

--- a/xk_handler/xk_index.py
+++ b/xk_handler/xk_index.py
@@ -2,7 +2,7 @@
 #-*- coding:utf8 -*-
 # Desgin By Xiaok
 from xk_application.xk_main import *
-import platform,os,sys
+import platform,os,sys,math
 
 class IndexHandler(BaseHandler):
     def get_hostname(self):

--- a/xk_handler/xk_index.py
+++ b/xk_handler/xk_index.py
@@ -170,7 +170,7 @@ class IndexHandler(BaseHandler):
         return cpu_infos
 
     def get_cpu(self):
-        cpu_infos = get_cpuinfo()
+        cpu_infos = self.get_cpuinfo()
         return (cpu_infos['']['idle']/cpu_infos['']['total'])
 
     @Auth


### PR DESCRIPTION
Output of `top` is highly inconsistent between versions and platforms.
Parsing the output of `top` can therefore cause the application to crash.
This PR removes the dependency on `top` output and instead parses the contents of /proc/stat to get CPU information.